### PR TITLE
Changes to the API request and response to match backbone changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: avgupta/chester:latest
+    image: registry.devshift.net/fabric8-analytics/f8a-chester:latest
     network_mode: bridge
     entrypoint:
       - /bin/entrypoint.sh

--- a/recommendation_engine/flask_predict.py
+++ b/recommendation_engine/flask_predict.py
@@ -52,7 +52,9 @@ def readiness():
 def recommendation():
     """Endpoint to serve recommendations."""
     global recommender
-    missing, recommendations = recommender.predict(request.json['stack'])
+    missing, recommendations = recommender.predict(
+            request.json['package_list'],
+            companion_threshold=request.json['comp_package_count_threshold'])
     return flask.jsonify({
         "missing_packages": missing,
         "companion_packages": recommendations,

--- a/recommendation_engine/flask_predict.py
+++ b/recommendation_engine/flask_predict.py
@@ -52,13 +52,14 @@ def readiness():
 def recommendation():
     """Endpoint to serve recommendations."""
     global recommender
-    missing, recommendations = recommender.predict(
+    missing, recommendations, ip_package_to_topic_dict = recommender.predict(
             request.json['package_list'],
             companion_threshold=request.json['comp_package_count_threshold'])
     return flask.jsonify({
         "missing_packages": missing,
         "companion_packages": recommendations,
-        "ecosystem": os.environ.get("CHESTER_SCORING_REGION")
+        "ecosystem": os.environ.get("CHESTER_SCORING_REGION"),
+        "package_to_topic_dict": ip_package_to_topic_dict
     }), 200
 
 

--- a/recommendation_engine/predictor/online_recommendation.py
+++ b/recommendation_engine/predictor/online_recommendation.py
@@ -120,9 +120,13 @@ class PMFRecommendation(AbstractRecommender):
                 missing.append(package)
             else:
                 avail.append(pkg_id)
+        package_topic_dict = {
+            self.package_id_name_map[str(package_id)]: self._package_tag_map.get(
+                self.package_id_name_map[str(package_id)], []) for package_id in avail
+        }
         # if more than half the packages are missing
         if len(missing) >= len(avail):
-            return missing, []
+            return missing, [], package_topic_dict
         new_user_stack = avail
         # Check whether we have already seen this stack.
         user = self._find_closest_user_in_training_set(new_user_stack)
@@ -157,4 +161,4 @@ class PMFRecommendation(AbstractRecommender):
                 "topic_list": self._package_tag_map.get(
                         self.package_id_name_map[str(package)], [])
             })
-        return missing, recommendations
+        return missing, recommendations, package_topic_dict

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -57,10 +57,12 @@ definitions:
     title: Request format for companion_recommendation endpoint
     description: Request format for companion_recommendation endpoint
     properties:
-      stack:
+      package_list:
         type: array
         items:
           type: string
+      comp_package_count_threshold:
+          type: number
   Response:
     title: Response containing the recommendations
     description: Response containing the recommendations
@@ -73,6 +75,13 @@ definitions:
           type: string
       companion_packages:
         $ref: '#/definitions/recommendation'
+      package_to_topic_dict:
+          type: object
+          properties:
+              package_name:
+                  type: array
+                  items:
+                      type: string
   recommendation:
     type: array
     items:

--- a/tests/unit_tests/test_PMFRecommendation.py
+++ b/tests/unit_tests/test_PMFRecommendation.py
@@ -49,11 +49,14 @@ class TestPMFRecommendation(TestCase):
     def test_predict(self):
         """Test the prediction flow."""
         # Test for a new stack.
-        missing, recommendation = self.pmf_rec.predict(['pon-logger'])
+        missing, recommendation, ptm = self.pmf_rec.predict(['pon-logger'])
         self.assertFalse(missing)
         # Should have two recommendations here.
         self.assertEqual(len(recommendation), 2)
 
         # Tests for missing package.
-        missing, _ = self.pmf_rec.predict(['pon-logger', 'missing'])
+        missing, _, _ = self.pmf_rec.predict(['pon-logger', 'missing'])
         self.assertTrue(missing)
+
+        missing, _, package_tag_map = self.pmf_rec.predict(['missing'])
+        self.assertDictEqual(package_tag_map, {})


### PR DESCRIPTION
- Change input stack key from 'stack' to 'package_list'
- Start returning the 'package_to_topic_dict' containing the input stack topics
- Change image name in docker compose to pull from devshift registry
- Get the companion threshold from backbone