### PR TITLE
Add recommendation engine to root for testing

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -5,6 +5,8 @@ LABEL MAINTAINER="Avishkar Gupta <avgupta@redhat.com>"
 # --------------------------------------------------------------------------------------------------
 # copy testing source code and scripts into root dir /
 # --------------------------------------------------------------------------------------------------
+
+ADD ./recommendation_engine /recommendation_engine
 ADD ./training/ /training
 ADD ./tests/ /tests
 ADD ./tests/scripts/entrypoint-test.sh /entrypoint-test.sh


### PR DESCRIPTION
As in unit testing, recommendation engine was not found by unit tests, so updated Dockerfile for the same