### PR TITLE
fix: upgrade numpy to be 1.16.5

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@ boto3==1.7.84
 daiquiri
 flask
 gevent==1.4.0
-numpy==1.16.1
+numpy==1.16.5
 scipy==1.2.1
 gunicorn
 raven[flask]

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ markupsafe==1.1.0
     # via
     #   -r requirements.in
     #   jinja2
-numpy==1.20.1
+numpy==1.16.5
     # via
     #   -r requirements.in
     #   h5py

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ markupsafe==1.1.0
     # via
     #   -r requirements.in
     #   jinja2
-numpy==1.16.1
+numpy==1.20.1
     # via
     #   -r requirements.in
     #   h5py


### PR DESCRIPTION
# Description

Pandas library used in tensflow needs numpy to be 1.16.5 or higher. This is the version with no vulnerabilities also. So, fixing this issue enabled NPM EMR flow.

Fixes # (issue)
https://issues.redhat.com/browse/APPAI-1693

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
